### PR TITLE
Fix: Linting, tests, addPlugin (fixes #19)

### DIFF
--- a/api/commands.js
+++ b/api/commands.js
@@ -28,7 +28,6 @@ export async function migrate ({ cwd = process.cwd(), journal, logger }) {
 export async function test ({ cwd = process.cwd(), logger } = {}) {
   return Task.runTests({
     cwd,
-    journal,
     logger
   })
 }

--- a/api/data.js
+++ b/api/data.js
@@ -12,7 +12,13 @@ export function checkContent (description, callback) {
   return deferOrRunWrap(function (context) {
     return successStopOrErrorWrap('checkContent', description, async () => {
       context.journal.freeze()
-      const result = await callback(context.content)
+      let result
+      try {
+        result = await callback(context.content)
+      } catch (err) {
+        context.journal.unfreeze()
+        throw err
+      }
       context.journal.unfreeze()
       return result
     })

--- a/api/plugins.js
+++ b/api/plugins.js
@@ -3,7 +3,6 @@ import { deferOrRunWrap, successStopOrErrorWrap } from '../lib/lifecycle.js'
 export function removePlugin (description, config) {
   return deferOrRunWrap(function (context) {
     return successStopOrErrorWrap('removePlugin', description, async () => {
-
       if (!description || !config) throw new Error('removePlugin - incorrectly configured')
 
       context.fromPlugins = context.fromPlugins.filter(plugin => plugin.name !== config.name)
@@ -16,12 +15,13 @@ export function removePlugin (description, config) {
 export function addPlugin (description, config) {
   return deferOrRunWrap(function (context) {
     return successStopOrErrorWrap('addPlugin', description, async () => {
-
       if (!description || !config) throw new Error('addPlugin - incorrectly configured')
 
       const newPlugin = context.toPlugins.find(plugin => (plugin.name === config.name))
       if (!newPlugin) throw new Error(`addPlugin - ${config.name} not found`)
-      context.fromPlugins.push(newPlugin[0])
+      context.fromPlugins.push(newPlugin)
+
+      return true
     })
   }, { description, type: 'action' })
 };
@@ -29,7 +29,6 @@ export function addPlugin (description, config) {
 export function updatePlugin (description, config) {
   return deferOrRunWrap(function (context) {
     return successStopOrErrorWrap('updatePlugin', description, async () => {
-
       if (!description || !config) throw new Error('updatePlugin - incorrectly configured')
 
       context.fromPlugins.forEach(plugin => {
@@ -37,10 +36,9 @@ export function updatePlugin (description, config) {
         plugin.version = config.version
         if (!config.framework) return
         plugin.framework = config.framework
-      });
+      })
 
       return true
     })
   }, { description, type: 'action' })
 };
-

--- a/lib/Logger.js
+++ b/lib/Logger.js
@@ -1,10 +1,10 @@
-import chalk from 'chalk';
-import path from 'path';
-import fs from 'fs-extra';
+import chalk from 'chalk'
+import path from 'path'
+import fs from 'fs-extra'
 
 export default class Logger {
   constructor () {
-    this.logArr = [];
+    this.logArr = []
     this.config = {
       levels: {
         error: {
@@ -24,11 +24,11 @@ export default class Logger {
   }
 
   // getInstance used to allow import
-  static getInstance() {
+  static getInstance () {
     if (Logger.instance === null) {
-      Logger.instance = new Logger();
+      Logger.instance = new Logger()
     }
-    return Logger.instance;
+    return Logger.instance
   }
 
   // Colour level string, easier to differentiate between info/error/warn/debug
@@ -48,42 +48,41 @@ export default class Logger {
   }
 
   // Add Success/Fail ?
-  info(...args) {
-    this.log('info', args);
+  info (...args) {
+    this.log('info', args)
   }
 
-  error(...args) {
-    this.log('error', args);
+  error (...args) {
+    this.log('error', args)
   }
 
-  warn(...args) {
-    this.log('warn', args);
+  warn (...args) {
+    this.log('warn', args)
   }
 
-  debug(...args) {
-    this.log('debug', args);
+  debug (...args) {
+    this.log('debug', args)
   }
 
-  //Colour level for easy read, store log in this.logArr as string
-  log(level, args) {
+  // Colour level for easy read, store log in this.logArr as string
+  log (level, args) {
     const colour = this?.config?.levels[level]?.colour || 'grey'
     const logFunc = console[level] ?? console.log
-    const dateStamp = Logger.getDateStamp();
-    const argsStr = args.join(', ');
+    const dateStamp = Logger.getDateStamp()
+    const argsStr = args.join(', ')
     logFunc(`(${dateStamp}) -- ${Logger.colourise(level, colour)} -- `, ...args)
     this.logArr.push(`[${dateStamp}] -- ${level} -- ${argsStr}`)
   }
 
   // Output this.logArr, 2 log outputs, capture & migrate
-  output(dir, type) {
+  output (dir, type) {
     const logPath = path.join(dir, './logs/')
-    if (!fs.existsSync(logPath)) fs.mkdirSync(logPath);
+    if (!fs.existsSync(logPath)) fs.mkdirSync(logPath)
 
     const outputName = `${type}_log`
     const outputFile = path.join(logPath, `${outputName}.json`)
-    fs.writeJSONSync(outputFile, this.logArr, { replacer: null, spaces: 2 });
+    fs.writeJSONSync(outputFile, this.logArr, { replacer: null, spaces: 2 })
   }
-
 }
 
-Logger.instance = null;
+Logger.instance = null

--- a/lib/Task.js
+++ b/lib/Task.js
@@ -219,8 +219,8 @@ export default class Task {
     fs.writeJsonSync(path.join(cachePath, 'package.json'), {
       name: 'migrations',
       type: 'module'
-    });
-    await new Promise(resolve => exec('npm install', { cwd: cachePath }, resolve));
+    })
+    await new Promise(resolve => exec('npm install', { cwd: cachePath }, resolve))
     const modules = await new Promise(resolve => {
       globs([
         '*.js'
@@ -276,7 +276,7 @@ export default class Task {
     }
   }
 
-  static async runTests ({ cwd = process.cwd(), journal, logger }) {
+  static async runTests ({ cwd = process.cwd(), logger }) {
     for (const task of Task.clonedItems) {
       logger.info(`Task -- Testing: ${task.description}`)
       for (const test of task.tests) {
@@ -291,11 +291,13 @@ export default class Task {
           content
         } = test()
         const journal = new Journal({
-          content,
-          fromPlugins,
-          originalFromPlugins,
-          toPlugins,
-          logger
+          logger,
+          data: {
+            content,
+            fromPlugins,
+            originalFromPlugins,
+            toPlugins
+          }
         })
         const {
           hasErrored,

--- a/lib/lifecycle.js
+++ b/lib/lifecycle.js
@@ -1,7 +1,7 @@
 import Task from './Task.js'
 import Logger from './Logger.js'
 
-const logger = Logger.getInstance();
+const logger = Logger.getInstance()
 
 function getCalleeName (step = 0) {
   const e = new Error('dummy')


### PR DESCRIPTION
* Removed undefined `journal` variable from test command
* Allow `checkContent` to unfreeze the journal if an error occurs
* `addPlugin` was returning undefined causing tasks to stop, it should return `true` so that `addPlugin` is considered a success not a stop and so if `addPlugin` appears anywhere but the bottom of a describe block the task will still proceed through its steps as expected
* `addPlugin` was using `[].find` which returns a single result from an array but `addPlugin` was then trying to lookup the first result from an imagined returned array (as if filter was called instead of find), corrected to use the single result directly
![image](https://github.com/user-attachments/assets/28e61683-9956-4414-9c2b-d67f0c7d6e6f)
![image](https://github.com/user-attachments/assets/b33d88dc-74ad-42b6-8620-134376138f9a)

* `runTests` updated to new journal arguments format

References:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter