### PR TITLE
Fix: Amend `getConfig` to tolerate items without `__path__` (fixes #53)

### DIFF
--- a/api/helpers.js
+++ b/api/helpers.js
@@ -5,7 +5,7 @@ function getContent() {
 }
 
 export function getConfig () {
-  return getContent().find(({ _type, __path__ }) => _type === 'config' || __path__.endsWith('config.json'))
+  return getContent().find(({ _type, __path__ }) => _type === 'config' || __path__?.endsWith('config.json'))
 }
 
 export function getCourse() {


### PR DESCRIPTION
### Fixes #53

### Fix

- Safe-nav on `__path__.endsWith(...)` in `api/helpers.js` `getConfig()` so it doesn't throw for in-memory content items that have no `__path__`.

### Testing

- [ ] Run a migration whose `whereContent` calls `getConfig` against an in-memory content array (no `__path__` on items) — no longer throws `TypeError: Cannot read properties of undefined (reading 'endsWith')`.
- [ ] File-based migrations (items populated with `__path__`) still match `config.json` via the `endsWith` branch.